### PR TITLE
Fix SBCL compiler note: complex type assertion

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -97,7 +97,9 @@ DEFINE-NAMESPACE defines 4 functions/macros:
             (:report (lambda (c s) (format s "Symbol ~a is unbound in namespace ~a"
                                            (cell-error-name c) ',name))))
           (deftype ,type () ',expected-type)
-          (declaim (ftype (function (symbol &optional (or null ,type)) (,type)) ,accessor)
+          (declaim (ftype (function (symbol &optional (or null ,type))
+                                    (values ,type &optional))
+                          ,accessor)
                    (ftype (function ((,type) symbol) (,type)) (setf ,accessor))
                    (inline ,accessor)
                    (inline (setf ,accessor)))


### PR DESCRIPTION
; note: Type assertion too complex to check:
; (VALUES LISP-NAMESPACE::%NAMESPACE &REST T).
; It allows an unknown number of values, consider using
; (VALUES LISP-NAMESPACE::%NAMESPACE &OPTIONAL).

Tested with SBCL, CCL, ECL, Allegro.